### PR TITLE
Send user_url for connecting services

### DIFF
--- a/includes/class-bridgy-config.php
+++ b/includes/class-bridgy-config.php
@@ -320,6 +320,7 @@ class Bridgy_Config {
 		echo '<input class="button-secondary" type="submit" value="' . $text . '" />' . '<br />';
 		echo '<input type="hidden" name="feature" value="' . implode( ',', $features ) . '" /><br />';
 		echo '<input type="hidden" name="callback" value="' . home_url( '/wp-admin/admin.php?page=bridgy_options&service=' ) . $service  . '" />';
+		echo '<input type="hidden" name="user_url" value="'. wp_get_current_user()->user_url . '" />';
 		echo '</form></p>';
 	}
 


### PR DESCRIPTION
user_url is now optional for all services, except instagram, this fixes #37

Aligns plugin with commit https://github.com/snarfed/bridgy/commit/ed03d92d92247fe28411ba8a9e999460c2a4c964