### PR TITLE
Update class-bridgy-postmeta.php

### DIFF
--- a/includes/class-bridgy-postmeta.php
+++ b/includes/class-bridgy-postmeta.php
@@ -230,7 +230,7 @@ class Bridgy_Postmeta {
 				$errors[] = $response->get_error_message();
 			}
 		}
-		$syn = get_post_meta( $post_id, 'mf2_syndication' );
+		$syn = get_post_meta( $post_id, 'mf2_syndication', true );
 
 		if ( ! empty( $returns ) ) {
 			if ( ! $syn ) {


### PR DESCRIPTION
mf2_syndication is an array stored in a single-row (hence we need to set single to true)

This fixes an issue where:
 1. OwnYourGram posts my post and sets a syndication
 2. Bridgy posts to FB & Twitter and sets a syndication, but did not merge the old one.

What it did - ![](https://puu.sh/y013y/300f79ae6e.png)