### PR TITLE
Update class-bridgy-postmeta.php

### DIFF
--- a/includes/class-bridgy-postmeta.php
+++ b/includes/class-bridgy-postmeta.php
@@ -293,7 +293,7 @@ class Bridgy_Postmeta {
 			echo '<data class="p-bridgy-omit-link" value="' . $backlink . '"></data>';
 		}
 		if ( ( '1' === get_option( 'bridgy_twitterexcerpt' ) ) && has_excerpt() ) {
-			echo '<p="p-bridgy-twitter-content" style="display:none"' . get_the_excerpt() . '</p>';
+			echo '<p class="p-bridgy-twitter-content" style="display:none"' . get_the_excerpt() . '</p>';
 		}
 	}
 


### PR DESCRIPTION
fix typo for missing `class` on `<p>` for bridgy twitter excerpt option. Fix for #39 
