### PR TITLE
Use admin_url() for successful bridgy callback

### DIFF
--- a/includes/class-bridgy-config.php
+++ b/includes/class-bridgy-config.php
@@ -319,7 +319,7 @@ class Bridgy_Config {
 		echo '<form method="post" action="https://brid.gy/' . $service . '/start">';
 		echo '<input class="button-secondary" type="submit" value="' . $text . '" />' . '<br />';
 		echo '<input type="hidden" name="feature" value="' . implode( ',', $features ) . '" /><br />';
-		echo '<input type="hidden" name="callback" value="' . home_url( '/wp-admin/admin.php?page=bridgy_options&service=' ) . $service  . '" />';
+		echo '<input type="hidden" name="callback" value="' . admin_url( 'admin.php?page=bridgy_options&service=' ) . $service  . '" />';
 		echo '<input type="hidden" name="user_url" value="'. wp_get_current_user()->user_url . '" />';
 		echo '</form></p>';
 	}


### PR DESCRIPTION
Using `home_url()` with hardcoded `/wp-admin` broke the flow of my bridgy callback since my WP installation is not in the root. Using `admin_url()` fixes this issue.