### PR TITLE
Improve label accessibility

### DIFF
--- a/includes/class-bridgy-postmeta.php
+++ b/includes/class-bridgy-postmeta.php
@@ -71,6 +71,7 @@ class Bridgy_Postmeta {
 			}
 			$string .= '<li>';
 			$string .= '<input type="checkbox" name="mf2_mp-syndicate-to[]"';
+			$string .= ' id="bridgy_' . $key . '"';
 			$string .= ' value="bridgy-publish_' . $key . '"';
 			if ( empty( $meta ) ) {
 				$string .= checked( $service, 'checked', false );


### PR DESCRIPTION
There is a missing `id` attribute on the silo checkbox input. Adding it makes the label text clickable and more accessible.