### PR TITLE
options_form was double running meta update/delete

### DIFF
--- a/includes/class-bridgy-config.php
+++ b/includes/class-bridgy-config.php
@@ -359,22 +359,6 @@ class Bridgy_Config {
 
 
 	public function options_form() {
-		if ( isset( $_GET['service'] ) ) {
-			switch ( $_GET['result'] ) {
-				case 'success':
-					update_user_meta( get_current_user_id(), 'bridgy-' . esc_attr( $_GET['service'] ), esc_url_raw( $_GET['user'] ) );
-					echo '<h2 class="notice notice-success">' . __( 'You have successfully registered', 'bridgy-publish' ) . '</h2>';
-					break;
-				case 'failure':
-					delete_user_meta( get_current_user_id(), 'bridgy-' . esc_attr( $_GET['service'] ) );
-					echo '<h2 class="notice notice-error">' . __( 'Your registration has failed', 'bridgy-publish' ) . '</h2>';
-					break;
-				case 'declined':
-					delete_user_meta( get_current_user_id(), 'bridgy-' . esc_attr( $_GET['service'] ) );
-					echo '<h2 class="notice notice-warning">' . __( 'Your registration have been declined', 'bridgy-publish' ) . '</h2>';
-					break;
-			}
-		}
 		load_template( plugin_dir_path( __DIR__ ) . 'templates/settings.php' );
 	}
 


### PR DESCRIPTION
Code that i removed is also in the `templates/settings.php` which seems like a better place?

Perhaps even better would be to restore the logic to the `options_form()` method and have it provide a `$option_message` or something that the `templates/settings.php` can render.